### PR TITLE
Workflow for the automatic creation of armv8 and amd64 docker images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: ci
+on:
+  workflow_dispatch:
+  #push:
+  #  paths-ignore:
+  #    - 'README.md'
+  #  branches:
+  #    - '**'
+
+jobs:
+  buildx:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get Version
+        id: get_version
+        uses: battila7/get-version-action@v2.3.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.7
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUBUNAME }}
+          password: ${{ secrets.DOCKERHUBTOKEN }} 
+      - name: Build only
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          push: true
+          tags: |
+            hvalev/genie-server:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: |
             hvalev/genie-server:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && \
         wget \
         curl \
         gnupg \
+        #for certs
+        libgnutls30 \ 
         pulseaudio \
         pulseaudio-utils \
         libpulse0 \
@@ -51,8 +53,6 @@ RUN \
         ninja-build \
         git \
         meson \
-        #for certs
-        libgnutls30 \ 
         libgstreamer1.0-dev \
         libasound2-dev \
         libglib2.0-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
         curl \
         gnupg \
         #for certs
-        libgnutls30 \ 
+#        libgnutls30 \ 
         pulseaudio \
         pulseaudio-utils \
         libpulse0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN \
         ninja-build \
         git \
         meson \
+        #for certs
+        libgnutls30 \ 
         libgstreamer1.0-dev \
         libasound2-dev \
         libglib2.0-dev \


### PR DESCRIPTION
Problem:
At present, there is no docker image for armv8/arm64/aarch64 architectures. A fairly sizable target for the genie-server are SBCs (Single Board Computers) such as Raspberry Pi/Orange Pi and others which are based on the ARM architecture as mentioned in https://github.com/stanford-oval/genie-server/issues/228. This PR addresses that.

Solution:
The following workflow file leverages Github Actions and GitHub infrastructure to (semi-)automatically build and push docker images to docker hub for both arm64 and amd64 architectures. On the client side, docker can detect and pull the image of the appropriate architecture. A build-log of a test-run of this workflow can be found here [here](https://github.com/hvalev/genie-server/actions/runs/1614677426) and the respective built docker images [here](https://hub.docker.com/repository/docker/hvalev/genie-server/tags?page=1&ordering=last_updated).

Important:
At present, this PR is a POC and is not ready to be merged. At present the workflow is manually triggered and pushes docker images with the :latest tag only. If this PR is positively perceived, I can adapt it to be triggered on commits where docker images are pushed with the tags :commit-hash and :latest or alternatively be triggered on new releases with tags :release_version and :latest. Alternative approaches are also welcome. A necessary input for this workflow to execute are the addition docker hub username and password as repository secrets (and optimally, a docker hub token, which can be used to update the docker hub image description using that in the github repository as accomplished [here](https://hub.docker.com/repository/docker/hvalev/shiny-server-arm)).